### PR TITLE
Adds frame compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raidguild/quiver",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "scripts": {
     "build": "pnpm run --recursive build",

--- a/packages/quiver/src/WalletContext.tsx
+++ b/packages/quiver/src/WalletContext.tsx
@@ -11,7 +11,7 @@ import { ICoreOptions } from 'web3modal';
 
 import { switchChainOnMetaMask } from './metamask';
 
-type WalletContextType = {
+export type WalletContextType = {
   provider: providers.Web3Provider | null | undefined;
   chainId: string | null | undefined;
   address: string | null | undefined;
@@ -196,7 +196,7 @@ export const WalletProvider: React.FC<{
        * This prevents unnecessary popup on page load.
        */
       const isMetamaskUnlocked =
-        (await window.ethereum?._metamask?.isUnlocked()) ?? false;
+        (await window.ethereum?._metamask?.isUnlocked?.()) ?? false;
       const modal = getModal();
       const _isGnosisSafe = await modal.isSafeApp();
 


### PR DESCRIPTION
Frame wallet, when impersonating Metamask, does not have the "isUnlocked" function.  This short-circuits that case.

And, adds an export of the type because it helps using Quiver in Typescript.